### PR TITLE
Add security update for cookies

### DIFF
--- a/docs/api/cookies.md
+++ b/docs/api/cookies.md
@@ -79,6 +79,7 @@ The following methods are available on instances of `Cookies`:
   * `secure` boolean (optional) - Filters cookies by their Secure property.
   * `session` boolean (optional) - Filters out session or persistent cookies.
   * `httpOnly` boolean (optional) - Filters cookies by httpOnly.
+  * `secureUpdate` boolean (optional) - Filters cookies by their Secure Update property.
 
 Returns `Promise<Cookie[]>` - A promise which resolves an array of cookie objects.
 
@@ -101,6 +102,7 @@ the response.
     seconds since the UNIX epoch. If omitted then the cookie becomes a session
     cookie and will not be retained between sessions.
   * `sameSite` string (optional) - The [Same Site](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) policy to apply to this cookie.  Can be `unspecified`, `no_restriction`, `lax` or `strict`.  Default is `lax`.
+  * `secureUpdate` boolean (optional) - Whether the cookie should be marked as Secure Update. Defaults to false.
 
 Returns `Promise<void>` - A promise which resolves when the cookie has been set
 
@@ -124,3 +126,7 @@ Writes any unwritten cookies data to disk
 Cookies written by any method will not be written to disk immediately, but will be written every 30 seconds or 512 operations
 
 Calling this method can cause the cookie to be written to disk immediately.
+
+### Security Update
+
+A new security feature has been added to the `Cookies` class. The `secureUpdate` property has been introduced to enhance the security of cookies. This property can be used in the `cookies.set` and `cookies.get` methods to set and filter cookies based on their Secure Update status.

--- a/docs/api/structures/cookie.md
+++ b/docs/api/structures/cookie.md
@@ -13,3 +13,4 @@
   the number of seconds since the UNIX epoch. Not provided for session
   cookies.
 * `sameSite` string - The [Same Site](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies) policy applied to this cookie.  Can be `unspecified`, `no_restriction`, `lax` or `strict`.
+* `secureUpdate` boolean (optional) - Whether the cookie is marked as Secure Update. This property enhances the security of cookies by ensuring that they are only sent over secure connections.

--- a/lib/browser/api/cookies.ts
+++ b/lib/browser/api/cookies.ts
@@ -1,0 +1,20 @@
+import { Cookie, Cookies } from 'electron';
+
+class SecureCookies extends Cookies {
+  async set(details: Electron.Cookie): Promise<void> {
+    if (details.secureUpdate) {
+      details.secure = true;
+    }
+    return super.set(details);
+  }
+
+  async get(filter: Electron.CookiesGetFilter): Promise<Electron.Cookie[]> {
+    const cookies = await super.get(filter);
+    if (filter.secureUpdate) {
+      return cookies.filter(cookie => cookie.secure);
+    }
+    return cookies;
+  }
+}
+
+export { SecureCookies };

--- a/spec/api-cookies-spec.ts
+++ b/spec/api-cookies-spec.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import { session } from 'electron';
+
+describe('Cookies API', () => {
+  let cookies;
+
+  before(() => {
+    cookies = session.defaultSession.cookies;
+  });
+
+  describe('cookies.set with secureUpdate', () => {
+    it('should set a cookie with secureUpdate', async () => {
+      const cookie = {
+        url: 'https://www.github.com',
+        name: 'secure_cookie',
+        value: 'dummy',
+        secureUpdate: true
+      };
+
+      await cookies.set(cookie);
+      const result = await cookies.get({ url: 'https://www.github.com', name: 'secure_cookie' });
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].name).to.equal('secure_cookie');
+      expect(result[0].value).to.equal('dummy');
+      expect(result[0].secure).to.be.true;
+    });
+  });
+
+  describe('cookies.get with secureUpdate filter', () => {
+    it('should get cookies with secureUpdate filter', async () => {
+      const cookie = {
+        url: 'https://www.github.com',
+        name: 'secure_cookie',
+        value: 'dummy',
+        secureUpdate: true
+      };
+
+      await cookies.set(cookie);
+      const result = await cookies.get({ secureUpdate: true });
+      expect(result).to.have.lengthOf.at.least(1);
+      expect(result.some(c => c.name === 'secure_cookie' && c.value === 'dummy' && c.secure)).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Add a security update for cookies.

* **Documentation Updates:**
  - Add `secureUpdate` property to `cookies.get` and `cookies.set` methods in `docs/api/cookies.md`.
  - Add a new section about the security update in `docs/api/cookies.md`.
  - Add `secureUpdate` field to the `Cookie` object in `docs/api/structures/cookie.md`.

* **Implementation:**
  - Create `lib/browser/api/cookies.ts` to implement the new security feature in `cookies.set` and `cookies.get` methods.

* **Testing:**
  - Add tests for the new security feature in `cookies.set` and `cookies.get` methods in `spec/api-cookies-spec.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/electron?shareId=1785db83-11bd-4614-8730-b622b23b8094).